### PR TITLE
Add Colemak keyboard layout

### DIFF
--- a/src/layouts/colemak.rs
+++ b/src/layouts/colemak.rs
@@ -1,0 +1,483 @@
+//! A Colemak 101-key (or 104-key including Windows keys) keyboard.
+//! Has a 1-row high Enter key, with Backslash above.
+
+use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
+
+pub struct Colemak;
+
+impl KeyboardLayout for Colemak {
+    fn map_keycode(
+        keycode: KeyCode,
+        modifiers: &Modifiers,
+        handle_ctrl: HandleControl,
+    ) -> DecodedKey {
+        let map_to_unicode = handle_ctrl == HandleControl::MapLettersToUnicode;
+        match keycode {
+            KeyCode::BackTick => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('~')
+                } else {
+                    DecodedKey::Unicode('`')
+                }
+            }
+            KeyCode::Escape => DecodedKey::Unicode(0x1B.into()),
+            KeyCode::Key1 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('!')
+                } else {
+                    DecodedKey::Unicode('1')
+                }
+            }
+            KeyCode::Key2 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('@')
+                } else {
+                    DecodedKey::Unicode('2')
+                }
+            }
+            KeyCode::Key3 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('#')
+                } else {
+                    DecodedKey::Unicode('3')
+                }
+            }
+            KeyCode::Key4 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('$')
+                } else {
+                    DecodedKey::Unicode('4')
+                }
+            }
+            KeyCode::Key5 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('%')
+                } else {
+                    DecodedKey::Unicode('5')
+                }
+            }
+            KeyCode::Key6 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('^')
+                } else {
+                    DecodedKey::Unicode('6')
+                }
+            }
+            KeyCode::Key7 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('&')
+                } else {
+                    DecodedKey::Unicode('7')
+                }
+            }
+            KeyCode::Key8 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('*')
+                } else {
+                    DecodedKey::Unicode('8')
+                }
+            }
+            KeyCode::Key9 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('(')
+                } else {
+                    DecodedKey::Unicode('9')
+                }
+            }
+            KeyCode::Key0 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode(')')
+                } else {
+                    DecodedKey::Unicode('0')
+                }
+            }
+            KeyCode::Minus => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('_')
+                } else {
+                    DecodedKey::Unicode('-')
+                }
+            }
+            KeyCode::Equals => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('+')
+                } else {
+                    DecodedKey::Unicode('=')
+                }
+            }
+            KeyCode::Backspace => DecodedKey::Unicode(0x08.into()),
+            KeyCode::Tab => DecodedKey::Unicode(0x09.into()),
+            KeyCode::Q => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0011}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('Q')
+                } else {
+                    DecodedKey::Unicode('q')
+                }
+            }
+            KeyCode::W => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0017}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('W')
+                } else {
+                    DecodedKey::Unicode('w')
+                }
+            }
+            KeyCode::E => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0006}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('F')
+                } else {
+                    DecodedKey::Unicode('f')
+                }
+            }
+            KeyCode::R => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0012}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('P')
+                } else {
+                    DecodedKey::Unicode('p')
+                }
+            }
+            KeyCode::T => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0007}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('G')
+                } else {
+                    DecodedKey::Unicode('g')
+                }
+            }
+            KeyCode::Y => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000A}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('J')
+                } else {
+                    DecodedKey::Unicode('j')
+                }
+            }
+            KeyCode::U => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000C}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('L')
+                } else {
+                    DecodedKey::Unicode('l')
+                }
+            }
+            KeyCode::I => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0015}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('U')
+                } else {
+                    DecodedKey::Unicode('u')
+                }
+            }
+            KeyCode::O => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0019}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('Y')
+                } else {
+                    DecodedKey::Unicode('y')
+                }
+            }
+            KeyCode::P => {
+                if modifiers.is_caps() {
+                    DecodedKey::Unicode(':')
+                } else {
+                    DecodedKey::Unicode(';')
+                }
+            }
+            KeyCode::BracketSquareLeft => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('{')
+                } else {
+                    DecodedKey::Unicode('[')
+                }
+            }
+            KeyCode::BracketSquareRight => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('}')
+                } else {
+                    DecodedKey::Unicode(']')
+                }
+            }
+            KeyCode::BackSlash => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('|')
+                } else {
+                    DecodedKey::Unicode('\\')
+                }
+            }
+            KeyCode::A => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0001}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('A')
+                } else {
+                    DecodedKey::Unicode('a')
+                }
+            }
+            KeyCode::S => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0012}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('R')
+                } else {
+                    DecodedKey::Unicode('r')
+                }
+            }
+            KeyCode::D => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0013}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('S')
+                } else {
+                    DecodedKey::Unicode('s')
+                }
+            }
+            KeyCode::F => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0014}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('T')
+                } else {
+                    DecodedKey::Unicode('t')
+                }
+            }
+            KeyCode::G => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0004}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('D')
+                } else {
+                    DecodedKey::Unicode('d')
+                }
+            }
+            KeyCode::H => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0008}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('H')
+                } else {
+                    DecodedKey::Unicode('h')
+                }
+            }
+            KeyCode::J => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000E}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('N')
+                } else {
+                    DecodedKey::Unicode('n')
+                }
+            }
+            KeyCode::K => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0005}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('E')
+                } else {
+                    DecodedKey::Unicode('e')
+                }
+            }
+            KeyCode::L => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0009}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('I')
+                } else {
+                    DecodedKey::Unicode('i')
+                }
+            }
+            KeyCode::SemiColon => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000F}')
+                } else if modifiers.is_shifted() {
+                    DecodedKey::Unicode('O')
+                } else {
+                    DecodedKey::Unicode('o')
+                }
+            }
+            KeyCode::Quote => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('"')
+                } else {
+                    DecodedKey::Unicode('\'')
+                }
+            }
+            // Enter gives LF, not CRLF or CR
+            KeyCode::Enter => DecodedKey::Unicode(10.into()),
+            KeyCode::Z => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{001A}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('Z')
+                } else {
+                    DecodedKey::Unicode('z')
+                }
+            }
+            KeyCode::X => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0018}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('X')
+                } else {
+                    DecodedKey::Unicode('x')
+                }
+            }
+            KeyCode::C => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0003}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('C')
+                } else {
+                    DecodedKey::Unicode('c')
+                }
+            }
+            KeyCode::V => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0016}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('V')
+                } else {
+                    DecodedKey::Unicode('v')
+                }
+            }
+            KeyCode::B => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0002}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('B')
+                } else {
+                    DecodedKey::Unicode('b')
+                }
+            }
+            KeyCode::N => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000B}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('K')
+                } else {
+                    DecodedKey::Unicode('k')
+                }
+            }
+            KeyCode::M => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000D}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('M')
+                } else {
+                    DecodedKey::Unicode('m')
+                }
+            }
+            KeyCode::Comma => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('<')
+                } else {
+                    DecodedKey::Unicode(',')
+                }
+            }
+            KeyCode::Fullstop => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('>')
+                } else {
+                    DecodedKey::Unicode('.')
+                }
+            }
+            KeyCode::Slash => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('?')
+                } else {
+                    DecodedKey::Unicode('/')
+                }
+            }
+            KeyCode::Spacebar => DecodedKey::Unicode(' '),
+            KeyCode::Delete => DecodedKey::Unicode(127.into()),
+            KeyCode::NumpadSlash => DecodedKey::Unicode('/'),
+            KeyCode::NumpadStar => DecodedKey::Unicode('*'),
+            KeyCode::NumpadMinus => DecodedKey::Unicode('-'),
+            KeyCode::Numpad7 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('7')
+                } else {
+                    DecodedKey::RawKey(KeyCode::Home)
+                }
+            }
+            KeyCode::Numpad8 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('8')
+                } else {
+                    DecodedKey::RawKey(KeyCode::ArrowUp)
+                }
+            }
+            KeyCode::Numpad9 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('9')
+                } else {
+                    DecodedKey::RawKey(KeyCode::PageUp)
+                }
+            }
+            KeyCode::NumpadPlus => DecodedKey::Unicode('+'),
+            KeyCode::Numpad4 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('4')
+                } else {
+                    DecodedKey::RawKey(KeyCode::ArrowLeft)
+                }
+            }
+            KeyCode::Numpad5 => DecodedKey::Unicode('5'),
+            KeyCode::Numpad6 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('6')
+                } else {
+                    DecodedKey::RawKey(KeyCode::ArrowRight)
+                }
+            }
+            KeyCode::Numpad1 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('1')
+                } else {
+                    DecodedKey::RawKey(KeyCode::End)
+                }
+            }
+            KeyCode::Numpad2 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('2')
+                } else {
+                    DecodedKey::RawKey(KeyCode::ArrowDown)
+                }
+            }
+            KeyCode::Numpad3 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('3')
+                } else {
+                    DecodedKey::RawKey(KeyCode::PageDown)
+                }
+            }
+            KeyCode::Numpad0 => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('0')
+                } else {
+                    DecodedKey::RawKey(KeyCode::Insert)
+                }
+            }
+            KeyCode::NumpadPeriod => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode('.')
+                } else {
+                    DecodedKey::Unicode(127.into())
+                }
+            }
+            KeyCode::NumpadEnter => DecodedKey::Unicode(10.into()),
+            k => DecodedKey::RawKey(k),
+        }
+    }
+}

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -18,3 +18,6 @@ pub use self::jis109::Jis109Key;
 
 mod azerty;
 pub use self::azerty::Azerty;
+
+mod colemak;
+pub use self::colemak::Colemak;


### PR DESCRIPTION
Fixes #11 

Adds the Colemak keyboard layout, which is the third most popular Latin-based keyboard layout after US and Dvorak.

Let me know if I need to make any changes.