### PR TITLE
Make Keyboard::new const fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,11 @@ where
     S: ScancodeSet,
 {
     /// Make a new Keyboard object with the given layout.
-    pub fn new(_layout: T, _set: S, handle_ctrl: HandleControl) -> Keyboard<T, S> {
+    pub const fn new(layout: T, set: S, handle_ctrl: HandleControl) -> Keyboard<T, S> {
+        // Bypass destructors, required for const fn
+        core::mem::forget(layout);
+        core::mem::forget(set);
+
         Keyboard {
             register: 0,
             num_bits: 0,


### PR DESCRIPTION
Keyboard::new can't be const because it's not const to drop generic values, but we can work around this limitation by simply not running destructors on the set and layout.
The drawback is that in the (unlikely) case where the user passes a type that needs to be dropped we might leak resources, maybe this is worth documenting?