### PR TITLE
Fix CTRL codes on AZERTY

### DIFF
--- a/src/layouts/azerty.rs
+++ b/src/layouts/azerty.rs
@@ -129,7 +129,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Tab => DecodedKey::Unicode(0x09.into()),
             KeyCode::Q => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0011}')
+                    DecodedKey::Unicode('\u{0001}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('A')
                 } else {
@@ -138,7 +138,7 @@ impl KeyboardLayout for Azerty {
             }
             KeyCode::W => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0017}')
+                    DecodedKey::Unicode('\u{001A}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('Z')
                 } else {
@@ -244,7 +244,7 @@ impl KeyboardLayout for Azerty {
             }
             KeyCode::A => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0001}')
+                    DecodedKey::Unicode('\u{0011}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('Q')
                 } else {
@@ -324,7 +324,9 @@ impl KeyboardLayout for Azerty {
                 }
             }
             KeyCode::SemiColon => {
-                if modifiers.is_shifted() {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000D}')
+                } else if modifiers.is_caps() {
                     DecodedKey::Unicode('M')
                 } else {
                     DecodedKey::Unicode('m')
@@ -341,7 +343,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Enter => DecodedKey::Unicode(10.into()),
             KeyCode::Z => {
                 if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{001A}')
+                    DecodedKey::Unicode('\u{0017}')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('W')
                 } else {
@@ -394,9 +396,7 @@ impl KeyboardLayout for Azerty {
                 }
             }
             KeyCode::M => {
-                if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{000D}')
-                } else if modifiers.is_caps() {
+                if modifiers.is_caps() {
                     DecodedKey::Unicode('?')
                 } else {
                     DecodedKey::Unicode(',')


### PR DESCRIPTION
I looked at the AZERTY code again and found other issues related to #10 that needed more changes.

Some CTRL codes associated with the letter keys were the same as on a QWERTY keyboard instead of being remapped to where they should be on an AZERTY keyboard.

I tested the changes on the text editor of [MOROS](https://github.com/vinc/moros) where some shortcuts (`^Q` and `^W` for example) where not working before the fix.

All the codes from 0x0001 to 0x001A are here without duplicates:

```
> grep "Unicode.'.u{" src/layouts/azerty.rs | sort
                    DecodedKey::Unicode('\u{0001}')
                    DecodedKey::Unicode('\u{0002}')
                    DecodedKey::Unicode('\u{0003}')
                    DecodedKey::Unicode('\u{0004}')
                    DecodedKey::Unicode('\u{0005}')
                    DecodedKey::Unicode('\u{0006}')
                    DecodedKey::Unicode('\u{0007}')
                    DecodedKey::Unicode('\u{0008}')
                    DecodedKey::Unicode('\u{0009}')
                    DecodedKey::Unicode('\u{000A}')
                    DecodedKey::Unicode('\u{000B}')
                    DecodedKey::Unicode('\u{000C}')
                    DecodedKey::Unicode('\u{000D}')
                    DecodedKey::Unicode('\u{000E}')
                    DecodedKey::Unicode('\u{000F}')
                    DecodedKey::Unicode('\u{0010}')
                    DecodedKey::Unicode('\u{0011}')
                    DecodedKey::Unicode('\u{0012}')
                    DecodedKey::Unicode('\u{0013}')
                    DecodedKey::Unicode('\u{0014}')
                    DecodedKey::Unicode('\u{0015}')
                    DecodedKey::Unicode('\u{0016}')
                    DecodedKey::Unicode('\u{0017}')
                    DecodedKey::Unicode('\u{0018}')
                    DecodedKey::Unicode('\u{0019}')
                    DecodedKey::Unicode('\u{001A}')
```