### PR TITLE
Split up the Keyboard type.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ keywords = ["arm", "cortex-m", "template", "video", "menu"]
 categories = ["embedded", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-embedded-community/pc-keyboard.git"
+edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -6,35 +6,45 @@ output directly).
 
 ## Supports:
 
--   Scancode Set 1 and 2
--   Dvorak 104-key layout
--   US 104-key layout
--   UK 105-key layout
--   JIS 109-key layout
--   Azerty full layout
+-   Scancode Set 1 (from the i8042 PC keyboard controller)
+-   Scancode Set 2 (direct from the AT or PS/2 interface keyboard)
+-   Several keyboard layouts:
+
+| Name                                                 | No. Keys | Description                                                              | Link                                                                                |
+| ---------------------------------------------------- | -------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| [`Us104`](./src/layouts/us104.rs)                    | 101/104  | North American standard English                                          | [Wikipedia](https://en.wikipedia.org/wiki/QWERTY#United_States)                     |
+| [`Uk105`](./src/layouts/uk105.rs)                    | 102/105  | United Kingdom standard English                                          | [Wikipedia](https://en.wikipedia.org/wiki/QWERTY#United_Kingdom)                    |
+| [`Azerty`](./src/layouts/azerty.rs)                  | 102/105  | Typically used in French locales                                         | [Wikipedia](https://en.wikipedia.org/wiki/AZERTY)                                   |
+| [`De104`](./src/layouts/de104.rs)                    | 102/105  | German layout                                                            | [Wikipedia](https://en.wikipedia.org/wiki/QWERTZ)                                   |
+| [`Jis109`](./src/layouts/jis109.rs)                  | 106/109  | JIS 109-key layout (Latin chars only)                                    | [Wikipedia](https://en.wikipedia.org/wiki/Japanese_input_method#Japanese_keyboards) |
+| [`Colemak`](./src/layouts/colemak.rs)                | 101/104  | A keyboard layout designed to make typing more efficient and comfortable | [Wikipedia](https://en.wikipedia.org/wiki/Colemak)                                  |
+| [`Dvorak104Key`](./src/layouts/dvorak104.rs)         | 101/104  | The more 'ergonomic' alternative to QWERTY                               | [Wikipedia](https://en.wikipedia.org/wiki/Dvorak_keyboard_layout)                   |
+| [`DVP104Key`](./src/layouts/dvorak_programmer104.rs) | 101/104  | Dvorak for Programmers                                                   | [Wikipedia](https://en.wikipedia.org/wiki/Dvorak_keyboard_layout#Programmer_Dvorak) |
+
+101/104 keys is ANSI layout (wide Enter key) and 102/105 keys is ISO layout
+(tall Enter key). The difference between 101 and 104 (and between 102 and
+105) comes from the two Windows keys and the Menu key that were added when
+Windows 95 came out. JIS keyboards have extra keys, added by making the
+space-bar and backspace keys shorter.
+
 
 ## Usage
 
-```rust
-extern crate pc_keyboard;
+There are three basic steps to handling keyboard input. Your application may bypass some of these.
 
-use pc_keyboard::{Keyboard, layouts, ScancodeSet2, HandleControl};
+* `Ps2Decoder` - converts 11-bit PS/2 words into bytes, removing the start/stop
+  bits and checking the parity bits. Only needed if you talk to the PS/2
+  keyboard over GPIO pins and not required if you talk to the i8042 PC keyboard
+  controller.
+* `ScancodeSet` - converts from Scancode Set 1 (i8042 PC keyboard controller) or
+  Scancode Set 2 (raw PS/2 keyboard output) into a symbolic `KeyCode` and an
+  up/down `KeyState`.
+* `EventDecoder` - converts symbolic `KeyCode` and `KeyState` into a Unicode
+  characters (where possible) according to the currently selected `KeyboardLayout`.
 
-fn main() {
-	let mut kb: Keyboard<layouts::Us104Key, ScancodeSet2> = Keyboard::new(HandleControl::MapLettersToUnicode);
-	match kb.add_byte(0x20) {
-		Ok(Some(event)) => {
-			println!("Event {:?}", event);
-		}
-		Ok(None) => {
-			println!("Need more data");
-		}
-		Err(e) => {
-			println!("Error decoding: {:?}", e);
-		}
-	}
-}
-```
+There is also `Keyboard` which combines the above three functions into a single object.
+
+See the [`examples`](./examples) folder for more details.
 
 ## [Documentation](https://docs.rs/crate/pc-keyboard)
 

--- a/examples/decoder.rs
+++ b/examples/decoder.rs
@@ -3,7 +3,7 @@ use pc_keyboard::Ps2Decoder;
 fn main() {
     let mut decoder = Ps2Decoder::new();
 
-    // If you get all 11 bits as on `u16`
+    // If you get all 11 bits as one `u16`
     match decoder.add_word(0x0402) {
         Ok(byte) => println!("Word 0x0402 is byte 0x{:02x}", byte),
         Err(e) => println!("Word 0x0402 failed to decode: {:?}", e),

--- a/examples/decoder.rs
+++ b/examples/decoder.rs
@@ -1,0 +1,33 @@
+use pc_keyboard::Ps2Decoder;
+
+fn main() {
+    let mut decoder = Ps2Decoder::new();
+
+    // If you get all 11 bits as on `u16`
+    match decoder.add_word(0x0402) {
+        Ok(byte) => println!("Word 0x0402 is byte 0x{:02x}", byte),
+        Err(e) => println!("Word 0x0402 failed to decode: {:?}", e),
+    }
+
+    // If you get a bit at a time
+    for bit in [
+        false, true, false, false, false, false, false, false, false, false, true,
+    ] {
+        match decoder.add_bit(bit) {
+            Ok(None) => println!("Added {}, not enough bits yet!", bit as u8),
+            Ok(Some(byte)) => println!("Added {}, got byte 0x{byte:02x}", bit as u8),
+            Err(e) => println!("Failed to decode: {e:?}"),
+        }
+    }
+
+    // Flipped a random bit, so we get a parity error
+    for bit in [
+        false, true, false, false, false, false, true, false, false, false, true,
+    ] {
+        match decoder.add_bit(bit) {
+            Ok(None) => println!("Added {}, not enough bits yet!", bit as u8),
+            Ok(Some(byte)) => println!("Added {}, got byte 0x{byte:02x}", bit as u8),
+            Err(e) => println!("Failed to decode: {e:?}"),
+        }
+    }
+}

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,0 +1,55 @@
+use pc_keyboard::{
+    layouts::{AnyLayout, Uk105Key},
+    DecodedKey, EventDecoder, KeyCode, KeyEvent, KeyState,
+};
+
+fn main() {
+    let mut decoder = EventDecoder::new(
+        AnyLayout::Uk105Key(Uk105Key),
+        pc_keyboard::HandleControl::Ignore,
+    );
+
+    // User presses 'A' on their UK keyboard, gets a lower-case 'a'.
+    let decoded_key = decoder.process_keyevent(KeyEvent {
+        code: KeyCode::A,
+        state: KeyState::Down,
+    });
+    assert_eq!(Some(DecodedKey::Unicode('a')), decoded_key);
+    println!("Got {:?}", decoded_key);
+
+    // User releases 'A' on their UK keyboard
+    let decoded_key = decoder.process_keyevent(KeyEvent {
+        code: KeyCode::A,
+        state: KeyState::Up,
+    });
+    assert_eq!(None, decoded_key);
+
+    // User presses 'Shift' on their UK keyboard
+    let decoded_key = decoder.process_keyevent(KeyEvent {
+        code: KeyCode::LShift,
+        state: KeyState::Down,
+    });
+    assert_eq!(None, decoded_key);
+
+    // User presses 'A' on their UK keyboard, now gets a Capital A
+    let decoded_key = decoder.process_keyevent(KeyEvent {
+        code: KeyCode::A,
+        state: KeyState::Down,
+    });
+    assert_eq!(Some(DecodedKey::Unicode('A')), decoded_key);
+    println!("Got {:?}", decoded_key);
+
+    // User releases 'A' on their UK keyboard
+    let decoded_key = decoder.process_keyevent(KeyEvent {
+        code: KeyCode::A,
+        state: KeyState::Up,
+    });
+    assert_eq!(None, decoded_key);
+
+    // User releases 'Shift' on their UK keyboard
+    let decoded_key = decoder.process_keyevent(KeyEvent {
+        code: KeyCode::LShift,
+        state: KeyState::Up,
+    });
+    assert_eq!(None, decoded_key);
+}

--- a/examples/scancodes.rs
+++ b/examples/scancodes.rs
@@ -1,0 +1,56 @@
+use pc_keyboard::{KeyEvent, ScancodeSet, ScancodeSet1, ScancodeSet2};
+
+fn main() {
+    let mut s = ScancodeSet1::new();
+    // [ 0x01 ] means "Pressed Escape" in Set 1
+    match s.advance_state(0x01) {
+        Ok(Some(KeyEvent { code, state })) => {
+            println!("Scancode Set 1 0x01 is KeyCode '{code:?}' KeyState '{state:?}'");
+        }
+        Ok(None) => {
+            println!("This is wrong, we didn't think that was a complete sequence");
+        }
+        Err(e) => {
+            println!("There was an error: {e:?}");
+        }
+    }
+    // [ 0x81 ] means "Released Escape" in Set 1
+    match s.advance_state(0x81) {
+        Ok(Some(KeyEvent { code, state })) => {
+            println!("Scancode Set 1 0x81 is KeyCode '{code:?}' KeyState '{state:?}'");
+        }
+        Ok(None) => {
+            println!("This is wrong, we didn't think that was a complete sequence");
+        }
+        Err(e) => {
+            println!("There was an error: {e:?}");
+        }
+    }
+
+    let mut s = ScancodeSet2::new();
+    // [ 0x01 ] means "Pressed F9" in Set 2
+    match s.advance_state(0x01) {
+        Ok(Some(KeyEvent { code, state })) => {
+            println!("Scancode Set 2 0x01 is KeyCode '{code:?}' KeyState '{state:?}'");
+        }
+        Ok(None) => {
+            println!("This is wrong, we didn't think that was a complete sequence");
+        }
+        Err(e) => {
+            println!("There was an error: {e:?}");
+        }
+    }
+    // [ 0xF0, 0x01 ] means "Released F9" in Set 2
+    assert_eq!(Ok(None), s.advance_state(0xF0));
+    match s.advance_state(0x01) {
+        Ok(Some(KeyEvent { code, state })) => {
+            println!("Scancode Set 2 0xF0 0x01 is KeyCode '{code:?}' KeyState '{state:?}'");
+        }
+        Ok(None) => {
+            println!("This is wrong, we didn't think that was a complete sequence");
+        }
+        Err(e) => {
+            println!("There was an error: {e:?}");
+        }
+    }
+}

--- a/src/layouts/azerty.rs
+++ b/src/layouts/azerty.rs
@@ -6,7 +6,7 @@ use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 ///
 /// The top row spells `AZERTY`.
 ///
-/// Has a 2-row high Enter key, with Backslash next to the left shift (ISO format).
+/// Has a 2-row high Enter key, with Oem5 next to the left shift (ISO format).
 pub struct Azerty;
 
 impl KeyboardLayout for Azerty {

--- a/src/layouts/azerty.rs
+++ b/src/layouts/azerty.rs
@@ -1,9 +1,17 @@
+//! French keyboard support
+
 use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
+/// A standard French 102-key (or 105-key including Windows keys) keyboard.
+///
+/// The top row spells `AZERTY`.
+///
+/// Has a 2-row high Enter key, with Backslash next to the left shift (ISO format).
 pub struct Azerty;
 
 impl KeyboardLayout for Azerty {
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,
@@ -514,7 +522,11 @@ mod test {
 
     #[test]
     fn test_frazert() {
-        let mut k = Keyboard::<Azerty, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            Azerty,
+            HandleControl::MapLettersToUnicode,
+        );
         assert_eq!(
             k.process_keyevent(KeyEvent::new(KeyCode::NumpadDivide, KeyState::Down)),
             Some(DecodedKey::Unicode('/'))

--- a/src/layouts/colemak.rs
+++ b/src/layouts/colemak.rs
@@ -1,12 +1,15 @@
-//! A Colemak 101-key (or 104-key including Windows keys) keyboard.
-//! Has a 1-row high Enter key, with Backslash above.
+//! The Colemak keyboard support
 
 use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
+/// A Colemak 101-key (or 104-key including Windows keys) keyboard.
+///
+/// Has a 1-row high Enter key, with Backslash above (ANSI layout).
 pub struct Colemak;
 
 impl KeyboardLayout for Colemak {
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,

--- a/src/layouts/colemak.rs
+++ b/src/layouts/colemak.rs
@@ -4,7 +4,7 @@ use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
 /// A Colemak 101-key (or 104-key including Windows keys) keyboard.
 ///
-/// Has a 1-row high Enter key, with Backslash above (ANSI layout).
+/// Has a 1-row high Enter key, with Oem7 above (ANSI layout).
 pub struct Colemak;
 
 impl KeyboardLayout for Colemak {

--- a/src/layouts/de104.rs
+++ b/src/layouts/de104.rs
@@ -1,11 +1,17 @@
+//! German keyboard support
+
 use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
-pub use super::us104::Us104Key;
+/// A standard German 102-key (or 105-key including Windows keys) keyboard.
+///
+/// The top row spells `QWERTZ`.
+///
+/// Has a 2-row high Enter key, with Backslash next to the left shift (ISO format).
+pub struct De105Key;
 
-pub struct De104Key;
-
-impl KeyboardLayout for De104Key {
+impl KeyboardLayout for De105Key {
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,
@@ -214,8 +220,10 @@ impl KeyboardLayout for De104Key {
                     DecodedKey::Unicode('<')
                 }
             }
-
-            e => <super::Us104Key as KeyboardLayout>::map_keycode(e, modifiers, handle_ctrl),
+            e => {
+                let us = super::Us104Key;
+                us.map_keycode(e, modifiers, handle_ctrl)
+            }
         }
     }
 }

--- a/src/layouts/de105.rs
+++ b/src/layouts/de105.rs
@@ -6,7 +6,7 @@ use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 ///
 /// The top row spells `QWERTZ`.
 ///
-/// Has a 2-row high Enter key, with Backslash next to the left shift (ISO format).
+/// Has a 2-row high Enter key, with Oem5 next to the left shift (ISO format).
 pub struct De105Key;
 
 impl KeyboardLayout for De105Key {

--- a/src/layouts/dvorak104.rs
+++ b/src/layouts/dvorak104.rs
@@ -1,14 +1,15 @@
-//! A Dvorak 101-key (or 104-key including Windows keys) keyboard.
-//! Has a 1-row high Enter key, with Backslash above.
+//! Dvorak keyboard support
 
 use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
-pub use super::us104::Us104Key;
-
+/// A Dvorak 101-key (or 104-key including Windows keys) keyboard.
+///
+/// Has a 1-row high Enter key, with Backslash above (ANSI layout).
 pub struct Dvorak104Key;
 
 impl KeyboardLayout for Dvorak104Key {
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,
@@ -294,7 +295,10 @@ impl KeyboardLayout for Dvorak104Key {
                     DecodedKey::Unicode('z')
                 }
             }
-            e => <super::Us104Key as KeyboardLayout>::map_keycode(e, modifiers, handle_ctrl),
+            e => {
+                let us = super::Us104Key;
+                us.map_keycode(e, modifiers, handle_ctrl)
+            }
         }
     }
 }

--- a/src/layouts/dvorak104.rs
+++ b/src/layouts/dvorak104.rs
@@ -4,7 +4,7 @@ use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
 /// A Dvorak 101-key (or 104-key including Windows keys) keyboard.
 ///
-/// Has a 1-row high Enter key, with Backslash above (ANSI layout).
+/// Has a 1-row high Enter key, with Oem7 above (ANSI layout).
 pub struct Dvorak104Key;
 
 impl KeyboardLayout for Dvorak104Key {

--- a/src/layouts/dvorak_programmer104.rs
+++ b/src/layouts/dvorak_programmer104.rs
@@ -4,7 +4,7 @@ use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
 /// A Dvorak Programmer 101-key (or 104-key including Windows keys) keyboard.
 ///
-/// Has a 1-row high Enter key, with Backslash above (ANSI layout)
+/// Has a 1-row high Enter key, with Oem7 above (ANSI layout).
 pub struct DVP104Key;
 
 impl KeyboardLayout for DVP104Key {

--- a/src/layouts/dvorak_programmer104.rs
+++ b/src/layouts/dvorak_programmer104.rs
@@ -1,12 +1,15 @@
-//! A Dvorak Programmer 101-key (or 104-key including Windows keys) keyboard.
-//! Has a 1-row high Enter key, with Backslash above.
+//! Dvorak Programmer keyboard support
 
 use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
+/// A Dvorak Programmer 101-key (or 104-key including Windows keys) keyboard.
+///
+/// Has a 1-row high Enter key, with Backslash above (ANSI layout)
 pub struct DVP104Key;
 
 impl KeyboardLayout for DVP104Key {
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,

--- a/src/layouts/jis109.rs
+++ b/src/layouts/jis109.rs
@@ -4,7 +4,7 @@ use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
 /// A standard Japan 106-key (or 109-key including Windows keys) keyboard.
 ///
-/// Has a small space bar, to fit in extra buttons.
+/// Has a small space bar, to fit in extra keys.
 pub struct Jis109Key;
 
 impl KeyboardLayout for Jis109Key {

--- a/src/layouts/jis109.rs
+++ b/src/layouts/jis109.rs
@@ -1,13 +1,15 @@
-/// A standard Japan 106-key (or 109-key including Windows keys) keyboard.
-/// Has a 2-row high Enter key, with Backslash above.
+//! JIS keyboard support
+
 use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
-pub use super::us104::Us104Key;
-
+/// A standard Japan 106-key (or 109-key including Windows keys) keyboard.
+///
+/// Has a small space bar, to fit in extra buttons.
 pub struct Jis109Key;
 
 impl KeyboardLayout for Jis109Key {
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,
@@ -140,7 +142,10 @@ impl KeyboardLayout for Jis109Key {
                     DecodedKey::Unicode('^')
                 }
             }
-            e => <Us104Key as KeyboardLayout>::map_keycode(e, modifiers, handle_ctrl),
+            e => {
+                let us = super::Us104Key;
+                us.map_keycode(e, modifiers, handle_ctrl)
+            }
         }
     }
 }

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -25,8 +25,8 @@ pub use self::azerty::Azerty;
 mod colemak;
 pub use self::colemak::Colemak;
 
-mod de104;
-pub use self::de104::De105Key;
+mod de105;
+pub use self::de105::De105Key;
 
 /// A enum of all the supported keyboard layouts.
 pub enum AnyLayout {

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! We have one layout per file, but where two layouts are similar, you can
 //! handle all the 'different' keys first, and then jump to another handler -
-//! see UK105 and US104 as an example of that.
+//! see [`Uk105Key`] and [`Us104Key`] as an example of that.
 
 mod dvorak_programmer104;
 pub use self::dvorak_programmer104::DVP104Key;
@@ -26,4 +26,81 @@ mod colemak;
 pub use self::colemak::Colemak;
 
 mod de104;
-pub use self::de104::De104Key;
+pub use self::de104::De105Key;
+
+/// A enum of all the supported keyboard layouts.
+pub enum AnyLayout {
+    DVP104Key(DVP104Key),
+    Dvorak104Key(Dvorak104Key),
+    Us104Key(Us104Key),
+    Uk105Key(Uk105Key),
+    Jis109Key(Jis109Key),
+    Azerty(Azerty),
+    Colemak(Colemak),
+    De105Key(De105Key),
+}
+
+impl super::KeyboardLayout for AnyLayout {
+    fn map_keycode(
+        &self,
+        keycode: super::KeyCode,
+        modifiers: &super::Modifiers,
+        handle_ctrl: super::HandleControl,
+    ) -> super::DecodedKey {
+        match self {
+            AnyLayout::DVP104Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Dvorak104Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Us104Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Uk105Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Jis109Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Azerty(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Colemak(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::De105Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+        }
+    }
+}
+
+impl super::KeyboardLayout for &AnyLayout {
+    fn map_keycode(
+        &self,
+        keycode: super::KeyCode,
+        modifiers: &super::Modifiers,
+        handle_ctrl: super::HandleControl,
+    ) -> super::DecodedKey {
+        match self {
+            AnyLayout::DVP104Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Dvorak104Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Us104Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Uk105Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Jis109Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Azerty(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::Colemak(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::De105Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::*;
+
+    #[test]
+    fn test_any() {
+        let mut decoder = EventDecoder::new(AnyLayout::Uk105Key(Uk105Key), HandleControl::Ignore);
+        // Q gets you a 'q'
+        let decoded = decoder.process_keyevent(KeyEvent {
+            code: KeyCode::Q,
+            state: KeyState::Down,
+        });
+        assert_eq!(decoded, Some(DecodedKey::Unicode('q')));
+        // Swap the layout
+        decoder.change_layout(AnyLayout::Azerty(Azerty));
+        // Q gets you a 'a'
+        let decoded = decoder.process_keyevent(KeyEvent {
+            code: KeyCode::Q,
+            state: KeyState::Down,
+        });
+        assert_eq!(decoded, Some(DecodedKey::Unicode('a')));
+    }
+}

--- a/src/layouts/uk105.rs
+++ b/src/layouts/uk105.rs
@@ -1,14 +1,15 @@
-//! A standard United Kingdom 102-key (or 105-key including Windows keys) keyboard.
-//! Has a 2-row high Enter key, with Backslash next to the left shift.
+//! United Kingdom keyboard support
 
 use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
-pub use super::us104::Us104Key;
-
+/// A standard United Kingdom 102-key (or 105-key including Windows keys) keyboard.
+///
+/// Has a 2-row high Enter key, with Backslash next to the left shift (ISO format).
 pub struct Uk105Key;
 
 impl KeyboardLayout for Uk105Key {
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,
@@ -67,7 +68,10 @@ impl KeyboardLayout for Uk105Key {
                     DecodedKey::Unicode('\\')
                 }
             }
-            e => <super::Us104Key as KeyboardLayout>::map_keycode(e, modifiers, handle_ctrl),
+            e => {
+                let us = super::Us104Key;
+                us.map_keycode(e, modifiers, handle_ctrl)
+            }
         }
     }
 }
@@ -79,7 +83,11 @@ mod test {
 
     #[test]
     fn test_hash() {
-        let mut k = Keyboard::<Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
         // As seen on a UK 105 key Dell PS/2 keyboard when pressing `~#`
         let ev = k.add_byte(0x5D).unwrap().unwrap();
         let decoded_key = k.process_keyevent(ev);
@@ -88,7 +96,11 @@ mod test {
 
     #[test]
     fn test_backslash() {
-        let mut k = Keyboard::<Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
         // As seen on a UK 105 key Dell PS/2 keyboard when pressing `|\`
         let ev = k.add_byte(0x61).unwrap().unwrap();
         let decoded_key = k.process_keyevent(ev);
@@ -97,7 +109,11 @@ mod test {
 
     #[test]
     fn test_tilde() {
-        let mut k = Keyboard::<Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
         // As seen on a UK 105 key Dell PS/2 keyboard when pressing Shift and `~#`
         let ev = k.add_byte(0x12).unwrap().unwrap();
         let _ = k.process_keyevent(ev);
@@ -108,7 +124,11 @@ mod test {
 
     #[test]
     fn test_pipe() {
-        let mut k = Keyboard::<Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
         // As seen on a UK 105 key Dell PS/2 keyboard when pressing Shift and `|\`
         let ev = k.add_byte(0x12).unwrap().unwrap();
         let _ = k.process_keyevent(ev);

--- a/src/layouts/uk105.rs
+++ b/src/layouts/uk105.rs
@@ -4,7 +4,7 @@ use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
 /// A standard United Kingdom 102-key (or 105-key including Windows keys) keyboard.
 ///
-/// Has a 2-row high Enter key, with Backslash next to the left shift (ISO format).
+/// Has a 2-row high Enter key, with Oem5 next to the left shift (ISO format).
 pub struct Uk105Key;
 
 impl KeyboardLayout for Uk105Key {

--- a/src/layouts/us104.rs
+++ b/src/layouts/us104.rs
@@ -4,7 +4,7 @@ use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
 /// A standard United States 101-key (or 104-key including Windows keys) keyboard.
 ///
-/// Has a 1-row high Enter key, with Backslash above (ANSI layout).
+/// Has a 1-row high Enter key, with Oem7 above (ANSI layout).
 pub struct Us104Key;
 
 impl KeyboardLayout for Us104Key {

--- a/src/layouts/us104.rs
+++ b/src/layouts/us104.rs
@@ -1,12 +1,15 @@
-//! A standard United States 101-key (or 104-key including Windows keys) keyboard.
-//! Has a 1-row high Enter key, with Backslash above.
+//! United States keyboard support
 
 use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
 
+/// A standard United States 101-key (or 104-key including Windows keys) keyboard.
+///
+/// Has a 1-row high Enter key, with Backslash above (ANSI layout).
 pub struct Us104Key;
 
 impl KeyboardLayout for Us104Key {
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,16 @@
 //! Driver for a PS/2 keyboard.
 //!
-//! Supports PS/2 Scan Code Set 1 and 2, on both UK and UK English keyboards. See [the
-//! OSDev Wiki](https://wiki.osdev.org/PS/2_Keyboard).
+//! Supports PS/2 Scan Code Set 1 and 2, on a variety of keyboard layouts. See
+//! [the OSDev Wiki](https://wiki.osdev.org/PS/2_Keyboard).
 //!
-//! Requires that you sample a pin in an interrupt routine and shift in the
-//! bit. We don't sample the pin in this library, as that makes testing
-//! difficult, and it means you have to make this object a global static mut
-//! that the interrupt can access, which is unsafe.
+//! Requires that you sample a pin in an interrupt routine and shift in the bit.
+//! We don't sample the pin in this library, as that makes testing difficult,
+//! and it means you have to make this object a global static mut that the
+//! interrupt can access, which is unsafe.
 
 #![cfg_attr(not(test), no_std)]
 #[cfg(test)]
 extern crate std as core;
-
-// ****************************************************************************
-//
-// Imports
-//
-// ****************************************************************************
-
-use core::marker::PhantomData;
 
 // ****************************************************************************
 //
@@ -37,20 +29,34 @@ pub use crate::scancodes::{ScancodeSet1, ScancodeSet2};
 //
 // ****************************************************************************
 
-/// `Keyboard<T, S>` encapsulates decode/sampling logic, and handles state transitions and key events.
+/// Encapsulates decode/sampling logic, and handles state transitions and key events.
 #[derive(Debug)]
-pub struct Keyboard<T, S>
+pub struct Keyboard<L, S>
 where
-    T: KeyboardLayout,
     S: ScancodeSet,
+    L: KeyboardLayout,
 {
+    ps2_decoder: Ps2Decoder,
+    scancode_set: S,
+    event_decoder: EventDecoder<L>,
+}
+
+/// Handles decoding of IBM PS/2 Keyboard (and IBM PC/AT Keyboard) bit-streams.
+#[derive(Debug)]
+pub struct Ps2Decoder {
     register: u16,
     num_bits: u8,
-    decode_state: DecodeState,
+}
+
+/// Converts KeyEvents into Unicode, according to the current Keyboard Layout
+#[derive(Debug)]
+pub struct EventDecoder<L>
+where
+    L: KeyboardLayout,
+{
     handle_ctrl: HandleControl,
     modifiers: Modifiers,
-    _layout: PhantomData<T>,
-    _set: PhantomData<S>,
+    layout: L,
 }
 
 /// Indicates different error conditions.
@@ -337,10 +343,15 @@ pub enum KeyCode {
     RAlt2,
 }
 
+/// The new state for a key, as part of a key event.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum KeyState {
+    /// Key has just been released
     Up,
+    /// Key has just been pressed
     Down,
+    /// Key was pressed and then released as an atomic action. Or it's like a
+    /// PowerOnSelfTest event which doesn't have an 'Up' or a 'Down'.
     SingleShot,
 }
 
@@ -357,18 +368,25 @@ pub enum HandleControl {
     Ignore,
 }
 
+/// A event describing something happen to a key on your keyboard.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct KeyEvent {
+    /// Which key this event is for
     pub code: KeyCode,
+    /// The new state for the key
     pub state: KeyState,
 }
 
+/// Describes a Keyboard Layout.
+///
+/// Layouts might include "en_US", or "en_GB", or "de_GR".
 pub trait KeyboardLayout {
     /// Convert a `KeyCode` enum to a Unicode character, if possible.
     /// `KeyCode::A` maps to `DecodedKey::Unicode('a')` (or
     /// `DecodedKey::Unicode('A')` if shifted), while `KeyCode::LAlt` becomes
     /// `DecodedKey::RawKey(KeyCode::LAlt)` because there's no Unicode equivalent.
     fn map_keycode(
+        &self,
         keycode: KeyCode,
         modifiers: &Modifiers,
         handle_ctrl: HandleControl,
@@ -376,13 +394,15 @@ pub trait KeyboardLayout {
 }
 
 /// A mechanism to convert bytes from a Keyboard into [`KeyCode`] values.
+///
+/// This conversion is stateful.
 pub trait ScancodeSet {
     /// Handles the state logic for the decoding of scan codes into key events.
-    fn advance_state(state: &mut DecodeState, code: u8) -> Result<Option<KeyEvent>, Error>;
+    fn advance_state(&mut self, code: u8) -> Result<Option<KeyEvent>, Error>;
 }
 
 /// The set of modifier keys you have on a keyboard.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Modifiers {
     /// The left shift key is down
     pub lshift: bool,
@@ -423,8 +443,9 @@ pub enum DecodedKey {
 //
 // ****************************************************************************
 
+/// Tracls
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum DecodeState {
+enum DecodeState {
     Start,
     Extended,
     Release,
@@ -450,17 +471,163 @@ const KEY_RELEASE_CODE: u8 = 0xF0;
 //
 // ****************************************************************************
 
-impl<T, S> Keyboard<T, S>
+impl<L, S> Keyboard<L, S>
 where
-    T: KeyboardLayout,
+    L: KeyboardLayout,
     S: ScancodeSet,
 {
     /// Make a new Keyboard object with the given layout.
-    pub const fn new(handle_ctrl: HandleControl) -> Keyboard<T, S> {
+    pub const fn new(scancode_set: S, layout: L, handle_ctrl: HandleControl) -> Keyboard<L, S> {
         Keyboard {
+            ps2_decoder: Ps2Decoder::new(),
+            scancode_set,
+            event_decoder: EventDecoder::new(layout, handle_ctrl),
+        }
+    }
+
+    /// Change the Ctrl key mapping.
+    pub fn set_ctrl_handling(&mut self, new_value: HandleControl) {
+        self.event_decoder.set_ctrl_handling(new_value);
+    }
+
+    /// Get the current Ctrl key mapping.
+    pub const fn get_ctrl_handling(&self) -> HandleControl {
+        self.event_decoder.get_ctrl_handling()
+    }
+
+    /// Clears the bit register.
+    ///
+    /// Call this when there is a timeout reading data from the keyboard.
+    pub fn clear(&mut self) {
+        self.ps2_decoder.clear();
+    }
+
+    /// Processes a 16-bit word from the keyboard.
+    ///
+    /// * The start bit (0) must be in bit 0.
+    /// * The data octet must be in bits 1..8, with the LSB in bit 1 and the
+    ///   MSB in bit 8.
+    /// * The parity bit must be in bit 9.
+    /// * The stop bit (1) must be in bit 10.
+    pub fn add_word(&mut self, word: u16) -> Result<Option<KeyEvent>, Error> {
+        let byte = self.ps2_decoder.add_word(word)?;
+        self.add_byte(byte)
+    }
+
+    /// Processes an 8-bit byte from the keyboard.
+    ///
+    /// We assume the start, stop and parity bits have been processed and
+    /// verified.
+    pub fn add_byte(&mut self, byte: u8) -> Result<Option<KeyEvent>, Error> {
+        self.scancode_set.advance_state(byte)
+    }
+
+    /// Shift a bit into the register.
+    ///
+    /// Call this /or/ call `add_word` - don't call both.
+    /// Until the last bit is added you get Ok(None) returned.
+    pub fn add_bit(&mut self, bit: bool) -> Result<Option<KeyEvent>, Error> {
+        if let Some(byte) = self.ps2_decoder.add_bit(bit)? {
+            self.scancode_set.advance_state(byte)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Processes a `KeyEvent` returned from `add_bit`, `add_byte` or `add_word`
+    /// and produces a decoded key.
+    ///
+    /// For example, the KeyEvent for pressing the '5' key on your keyboard
+    /// gives a DecodedKey of unicode character '5', unless the shift key is
+    /// held in which case you get the unicode character '%'.
+    pub fn process_keyevent(&mut self, ev: KeyEvent) -> Option<DecodedKey> {
+        self.event_decoder.process_keyevent(ev)
+    }
+}
+
+impl Ps2Decoder {
+    /// Build a new PS/2 protocol decoder.
+    pub const fn new() -> Ps2Decoder {
+        Ps2Decoder {
             register: 0,
             num_bits: 0,
-            decode_state: DecodeState::Start,
+        }
+    }
+
+    /// Clears the bit register.
+    ///
+    /// Call this when there is a timeout reading data from the keyboard.
+    pub fn clear(&mut self) {
+        self.register = 0;
+        self.num_bits = 0;
+    }
+
+    /// Shift a bit into the register.
+    ///
+    /// Until the last bit is added you get Ok(None) returned.
+    pub fn add_bit(&mut self, bit: bool) -> Result<Option<u8>, Error> {
+        self.register |= (bit as u16) << self.num_bits;
+        self.num_bits += 1;
+        if self.num_bits == KEYCODE_BITS {
+            let word = self.register;
+            self.register = 0;
+            self.num_bits = 0;
+            let byte = Self::check_word(word)?;
+            Ok(Some(byte))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Process an entire 11-bit word.
+    ///
+    /// Must be packed into the bottom 11-bits of the 16-bit value.
+    pub fn add_word(&self, word: u16) -> Result<u8, Error> {
+        Self::check_word(word)
+    }
+
+    /// Check 11-bit word has 1 start bit, 1 stop bit and an odd parity bit.
+    const fn check_word(word: u16) -> Result<u8, Error> {
+        let start_bit = Self::get_bit(word, 0);
+        let parity_bit = Self::get_bit(word, 9);
+        let stop_bit = Self::get_bit(word, 10);
+        let data = ((word >> 1) & 0xFF) as u8;
+
+        if start_bit {
+            return Err(Error::BadStartBit);
+        }
+
+        if !stop_bit {
+            return Err(Error::BadStopBit);
+        }
+
+        // We have odd parity, so if there are an even number of 1 bits, we need
+        // the parity bit set to make it odd.
+        let need_parity = Self::has_even_number_bits(data);
+
+        if need_parity != parity_bit {
+            return Err(Error::ParityError);
+        }
+
+        Ok(data)
+    }
+
+    const fn get_bit(word: u16, offset: usize) -> bool {
+        ((word >> offset) & 0x0001) != 0
+    }
+
+    const fn has_even_number_bits(data: u8) -> bool {
+        (data.count_ones() % 2) == 0
+    }
+}
+
+impl<L> EventDecoder<L>
+where
+    L: KeyboardLayout,
+{
+    /// Construct a new event decoder.
+    pub const fn new(layout: L, handle_ctrl: HandleControl) -> EventDecoder<L> {
+        EventDecoder {
             handle_ctrl,
             modifiers: Modifiers {
                 lshift: false,
@@ -472,8 +639,7 @@ where
                 alt_gr: false,
                 rctrl2: false,
             },
-            _layout: PhantomData,
-            _set: PhantomData,
+            layout,
         }
     }
 
@@ -485,52 +651,6 @@ where
     /// Get the current Ctrl key mapping.
     pub const fn get_ctrl_handling(&self) -> HandleControl {
         self.handle_ctrl
-    }
-
-    /// Clears the bit register.
-    ///
-    /// Call this when there is a timeout reading data from the keyboard.
-    pub fn clear(&mut self) {
-        self.register = 0;
-        self.num_bits = 0;
-        self.decode_state = DecodeState::Start;
-    }
-
-    /// Processes a 16-bit word from the keyboard.
-    ///
-    /// * The start bit (0) must be in bit 0.
-    /// * The data octet must be in bits 1..8, with the LSB in bit 1 and the
-    ///   MSB in bit 8.
-    /// * The parity bit must be in bit 9.
-    /// * The stop bit (1) must be in bit 10.
-    pub fn add_word(&mut self, word: u16) -> Result<Option<KeyEvent>, Error> {
-        let byte = Self::check_word(word)?;
-        self.add_byte(byte)
-    }
-
-    /// Processes an 8-bit byte from the keyboard.
-    ///
-    /// We assume the start, stop and parity bits have been processed and
-    /// verified.
-    pub fn add_byte(&mut self, byte: u8) -> Result<Option<KeyEvent>, Error> {
-        S::advance_state(&mut self.decode_state, byte)
-    }
-
-    /// Shift a bit into the register.
-    ///
-    /// Call this /or/ call `add_word` - don't call both.
-    /// Until the last bit is added you get Ok(None) returned.
-    pub fn add_bit(&mut self, bit: bool) -> Result<Option<KeyEvent>, Error> {
-        self.register |= (bit as u16) << self.num_bits;
-        self.num_bits += 1;
-        if self.num_bits == KEYCODE_BITS {
-            let word = self.register;
-            self.register = 0;
-            self.num_bits = 0;
-            self.add_word(word)
-        } else {
-            Ok(None)
-        }
     }
 
     /// Processes a `KeyEvent` returned from `add_bit`, `add_byte` or `add_word`
@@ -649,42 +769,20 @@ where
             KeyEvent {
                 code: c,
                 state: KeyState::Down,
-            } => Some(T::map_keycode(c, &self.modifiers, self.handle_ctrl)),
+            } => Some(
+                self.layout
+                    .map_keycode(c, &self.modifiers, self.handle_ctrl),
+            ),
             _ => None,
         }
     }
 
-    const fn get_bit(word: u16, offset: usize) -> bool {
-        ((word >> offset) & 0x0001) != 0
-    }
-
-    const fn has_even_number_bits(data: u8) -> bool {
-        (data.count_ones() % 2) == 0
-    }
-
-    /// Check 11-bit word has 1 start bit, 1 stop bit and an odd parity bit.
-    const fn check_word(word: u16) -> Result<u8, Error> {
-        let start_bit = Self::get_bit(word, 0);
-        let parity_bit = Self::get_bit(word, 9);
-        let stop_bit = Self::get_bit(word, 10);
-        let data = ((word >> 1) & 0xFF) as u8;
-
-        if start_bit {
-            return Err(Error::BadStartBit);
-        }
-
-        if !stop_bit {
-            return Err(Error::BadStopBit);
-        }
-
-        let need_parity = Self::has_even_number_bits(data);
-
-        // Odd parity, so these must not match
-        if need_parity != parity_bit {
-            return Err(Error::ParityError);
-        }
-
-        Ok(data)
+    /// Change the keyboard layout.
+    ///
+    /// Only useful with [`layouts::AnyLayout`], otherwise you can only change a
+    /// layout for exactly the same layout.
+    pub fn change_layout(&mut self, new_layout: L) {
+        self.layout = new_layout;
     }
 }
 
@@ -724,9 +822,9 @@ impl Modifiers {
 mod test {
     use super::*;
 
-    fn add_bytes<T, S>(keyboard: &mut Keyboard<T, S>, test_sequence: &[(u8, Option<KeyEvent>)])
+    fn add_bytes<L, S>(keyboard: &mut Keyboard<L, S>, test_sequence: &[(u8, Option<KeyEvent>)])
     where
-        T: KeyboardLayout,
+        L: KeyboardLayout,
         S: ScancodeSet,
     {
         for (byte, expected_key) in test_sequence.iter().cloned() {
@@ -742,11 +840,11 @@ mod test {
         }
     }
 
-    fn process_keyevents<T, S>(
-        keyboard: &mut Keyboard<T, S>,
+    fn process_keyevents<L, S>(
+        keyboard: &mut Keyboard<L, S>,
         test_sequence: &[(KeyEvent, Option<DecodedKey>)],
     ) where
-        T: KeyboardLayout,
+        L: KeyboardLayout,
         S: ScancodeSet,
     {
         for (idx, (event, expected_decode)) in test_sequence.iter().cloned().enumerate() {
@@ -765,8 +863,11 @@ mod test {
 
     #[test]
     fn test_f9() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         // start
         assert_eq!(k.add_bit(false), Ok(None));
         // 8 data bits (LSB first)
@@ -789,8 +890,11 @@ mod test {
 
     #[test]
     fn test_f9_word() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         assert_eq!(
             k.add_word(0x0402),
             Ok(Some(KeyEvent::new(KeyCode::F9, KeyState::Down)))
@@ -799,8 +903,11 @@ mod test {
 
     #[test]
     fn test_f9_byte() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
 
         let test_sequence = [(0x01, Some(KeyEvent::new(KeyCode::F9, KeyState::Down)))];
         add_bytes(&mut k, &test_sequence);
@@ -808,8 +915,11 @@ mod test {
 
     #[test]
     fn test_keyup_keydown() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [
             (0x01, Some(KeyEvent::new(KeyCode::F9, KeyState::Down))),
             (0x01, Some(KeyEvent::new(KeyCode::F9, KeyState::Down))),
@@ -821,8 +931,11 @@ mod test {
 
     #[test]
     fn test_f5() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         // start
         assert_eq!(k.add_bit(false), Ok(None));
         // 8 data bits (LSB first)
@@ -845,8 +958,11 @@ mod test {
 
     #[test]
     fn test_f5_up() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         // Send F0
 
         // start
@@ -889,8 +1005,11 @@ mod test {
 
     #[test]
     fn test_shift() {
-        let mut k =
-            Keyboard::<layouts::Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [
             // A with left shift held
             (KeyEvent::new(KeyCode::LShift, KeyState::Down), None),
@@ -944,8 +1063,11 @@ mod test {
 
     #[test]
     fn test_ctrl() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [
             // Normal
             (
@@ -981,8 +1103,11 @@ mod test {
 
     #[test]
     fn test_numlock() {
-        let mut k =
-            Keyboard::<layouts::Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
 
         let test_sequence = [
             // Numlock ON by default so we get digits
@@ -1006,8 +1131,11 @@ mod test {
 
     #[test]
     fn test_set_1_down_up_down() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet1>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet1::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [
             (0x1e, Some(KeyEvent::new(KeyCode::A, KeyState::Down))),
             (0x9e, Some(KeyEvent::new(KeyCode::A, KeyState::Up))),
@@ -1019,8 +1147,11 @@ mod test {
 
     #[test]
     fn test_set_1_ext_down_up_down() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet1>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet1::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [
             (0xe0, None),
             (
@@ -1038,8 +1169,11 @@ mod test {
 
     #[test]
     fn test_set_2_poweron() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [(
             0xAA,
             Some(KeyEvent::new(KeyCode::PowerOnTestOk, KeyState::SingleShot)),
@@ -1049,8 +1183,11 @@ mod test {
 
     #[test]
     fn test_set_2_toomanykeys() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [(
             0x00,
             Some(KeyEvent::new(KeyCode::TooManyKeys, KeyState::SingleShot)),
@@ -1060,8 +1197,11 @@ mod test {
 
     #[test]
     fn test_set_2_down_up() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [
             (0x29, Some(KeyEvent::new(KeyCode::Spacebar, KeyState::Down))),
             (0xF0, None),
@@ -1078,8 +1218,11 @@ mod test {
 
     #[test]
     fn test_set_2_ext_down_up() {
-        let mut k =
-            Keyboard::<layouts::Us104Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Us104Key,
+            HandleControl::MapLettersToUnicode,
+        );
         let test_sequence = [
             (0xE0, None),
             (0x6C, Some(KeyEvent::new(KeyCode::Home, KeyState::Down))),
@@ -1092,8 +1235,11 @@ mod test {
 
     #[test]
     fn test_pause_set1() {
-        let mut k =
-            Keyboard::<layouts::Uk105Key, ScancodeSet1>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet1::new(),
+            layouts::Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
 
         // A Pause keypress generates this sequence all in one go. There is no
         // 'Break' code for this key.
@@ -1139,8 +1285,11 @@ mod test {
 
     #[test]
     fn test_pause_set2() {
-        let mut k =
-            Keyboard::<layouts::Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
 
         // A Pause keypress generates this sequence all in one go. There is no
         // 'Break' code for this key.
@@ -1187,8 +1336,11 @@ mod test {
 
     #[test]
     fn test_pause_events() {
-        let mut k =
-            Keyboard::<layouts::Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
 
         // A Pause keypress generates this sequence all in one go. There is no
         // 'Break' code for this key.
@@ -1231,8 +1383,11 @@ mod test {
 
     #[test]
     fn test_print_screen_set1() {
-        let mut k =
-            Keyboard::<layouts::Uk105Key, ScancodeSet1>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet1::new(),
+            layouts::Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
 
         // A Print Screen keypress generates this sequence on make and break.
         let test_sequence = [
@@ -1278,8 +1433,11 @@ mod test {
 
     #[test]
     fn test_print_screen_set2() {
-        let mut k =
-            Keyboard::<layouts::Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
 
         // A Print Screen keypress generates this sequence on make and break.
         let test_sequence = [
@@ -1328,8 +1486,11 @@ mod test {
 
     #[test]
     fn test_print_screen_events() {
-        let mut k =
-            Keyboard::<layouts::Uk105Key, ScancodeSet2>::new(HandleControl::MapLettersToUnicode);
+        let mut k = Keyboard::new(
+            ScancodeSet2::new(),
+            layouts::Uk105Key,
+            HandleControl::MapLettersToUnicode,
+        );
 
         // A Print Screen keypress generates this sequence on make and break.
         let test_sequence = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,23 @@
-//! Driver for a PS/2 keyboard.
+//! Driver for a PS/2 PC keyboard.
 //!
 //! Supports PS/2 Scan Code Set 1 and 2, on a variety of keyboard layouts. See
 //! [the OSDev Wiki](https://wiki.osdev.org/PS/2_Keyboard).
 //!
-//! Requires that you sample a pin in an interrupt routine and shift in the bit.
-//! We don't sample the pin in this library, as that makes testing difficult,
-//! and it means you have to make this object a global static mut that the
-//! interrupt can access, which is unsafe.
+//! There are three basic steps to handling keyboard input. Your application may bypass some of these.
+//!
+//! * [`Ps2Decoder`] - converts 11-bit PS/2 words into bytes, removing the start/stop
+//!   bits and checking the parity bits. Only needed if you talk to the PS/2
+//!   keyboard over GPIO pins and not required if you talk to the i8042 PC keyboard
+//!   controller.
+//! * [`ScancodeSet`] - converts from Scancode Set 1 (i8042 PC keyboard controller) or
+//!   Scancode Set 2 (raw PS/2 keyboard output) into a symbolic [`KeyCode`] and an
+//!   up/down [`KeyState`].
+//! * [`EventDecoder`] - converts symbolic [`KeyCode`] and [`KeyState`] into a Unicode
+//!   characters (where possible) according to the currently selected `KeyboardLayout`.
+//!
+//! There is also [`Keyboard`] which combines the above three functions into a single object.
 
 #![cfg_attr(not(test), no_std)]
-#[cfg(test)]
-extern crate std as core;
 
 // ****************************************************************************
 //


### PR DESCRIPTION
We now have separate types for decoding the PS/2 bitstream, processing Scan Codes into KeyEvents, and decoding KeyEvents according to the current layout.

Also adds an 'AnyLayout' type which lets you swap layouts at run-time.

Closes #30 