### PR TITLE
Update AltGr handling to accept Ctrl+Alt, add Norwegian keyboard layout

### DIFF
--- a/src/layouts/azerty.rs
+++ b/src/layouts/azerty.rs
@@ -37,7 +37,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key2 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('2')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('~')
                 } else {
                     DecodedKey::Unicode('é')
@@ -46,7 +46,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key3 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('3')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('#')
                 } else {
                     DecodedKey::Unicode('"')
@@ -55,7 +55,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key4 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('4')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('{')
                 } else {
                     DecodedKey::Unicode('\'')
@@ -64,7 +64,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key5 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('5')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('[')
                 } else {
                     DecodedKey::Unicode('(')
@@ -73,7 +73,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key6 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('6')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('|')
                 } else {
                     DecodedKey::Unicode('-')
@@ -82,7 +82,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key7 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('7')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('`')
                 } else {
                     DecodedKey::Unicode('è')
@@ -91,7 +91,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key8 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('8')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('\\')
                 } else {
                     DecodedKey::Unicode('_')
@@ -100,7 +100,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key9 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('9')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('^')
                 } else {
                     DecodedKey::Unicode('ç')
@@ -109,7 +109,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Key0 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('0')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('@')
                 } else {
                     DecodedKey::Unicode('à')
@@ -118,7 +118,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::OemMinus => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('°')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode(']')
                 } else {
                     DecodedKey::Unicode(')')
@@ -127,7 +127,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::OemPlus => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('+')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('}')
                 } else {
                     DecodedKey::Unicode('=')
@@ -228,7 +228,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Oem4 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('¨')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('ˇ')
                 } else {
                     DecodedKey::Unicode('^')
@@ -237,7 +237,7 @@ impl KeyboardLayout for Azerty {
             KeyCode::Oem6 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('£')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('¤')
                 } else {
                     DecodedKey::Unicode('$')

--- a/src/layouts/de105.rs
+++ b/src/layouts/de105.rs
@@ -115,7 +115,7 @@ impl KeyboardLayout for De105Key {
             KeyCode::Q => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{0011}')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('@')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('Q')
@@ -126,7 +126,7 @@ impl KeyboardLayout for De105Key {
             KeyCode::E => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{0005}')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('€')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('E')
@@ -151,7 +151,7 @@ impl KeyboardLayout for De105Key {
                 }
             }
             KeyCode::Oem6 => {
-                if modifiers.alt_gr {
+                if modifiers.is_altgr() {
                     DecodedKey::Unicode('~')
                 } else if modifiers.is_caps() {
                     DecodedKey::Unicode('*')
@@ -214,7 +214,7 @@ impl KeyboardLayout for De105Key {
             KeyCode::Oem5 => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode('>')
-                } else if modifiers.alt_gr {
+                } else if modifiers.is_altgr() {
                     DecodedKey::Unicode('|')
                 } else {
                     DecodedKey::Unicode('<')

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -28,6 +28,9 @@ pub use self::colemak::Colemak;
 mod de105;
 pub use self::de105::De105Key;
 
+mod no105;
+pub use self::no105::No105Key;
+
 /// A enum of all the supported keyboard layouts.
 pub enum AnyLayout {
     DVP104Key(DVP104Key),
@@ -38,6 +41,7 @@ pub enum AnyLayout {
     Azerty(Azerty),
     Colemak(Colemak),
     De105Key(De105Key),
+    No105Key(No105Key),
 }
 
 impl super::KeyboardLayout for AnyLayout {
@@ -56,6 +60,7 @@ impl super::KeyboardLayout for AnyLayout {
             AnyLayout::Azerty(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
             AnyLayout::Colemak(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
             AnyLayout::De105Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::No105Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
         }
     }
 }
@@ -76,6 +81,7 @@ impl super::KeyboardLayout for &AnyLayout {
             AnyLayout::Azerty(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
             AnyLayout::Colemak(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
             AnyLayout::De105Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
+            AnyLayout::No105Key(inner) => inner.map_keycode(keycode, modifiers, handle_ctrl),
         }
     }
 }

--- a/src/layouts/no105.rs
+++ b/src/layouts/no105.rs
@@ -1,0 +1,223 @@
+//! Norwegian keyboard support
+
+use crate::{DecodedKey, HandleControl, KeyCode, KeyboardLayout, Modifiers};
+
+/// A standard Norwegian 102-key (or 105-key including Windows keys) keyboard.
+///
+/// Has a 2-row high Enter key, with Oem5 next to the left shift (ISO format).
+pub struct No105Key;
+
+impl KeyboardLayout for No105Key {
+    fn map_keycode(
+        &self,
+        keycode: KeyCode,
+        modifiers: &Modifiers,
+        handle_ctrl: HandleControl,
+    ) -> DecodedKey {
+        let map_to_unicode = handle_ctrl == HandleControl::MapLettersToUnicode;
+        match keycode {
+            KeyCode::Escape => DecodedKey::Unicode(0x1B.into()),
+            KeyCode::Oem8 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('§')
+                } else {
+                    DecodedKey::Unicode('|')
+                }
+            }
+            KeyCode::Key1 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('!')
+                } else {
+                    DecodedKey::Unicode('1')
+                }
+            }
+            KeyCode::Key2 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('"')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('@')
+                } else {
+                    DecodedKey::Unicode('2')
+                }
+            }
+            KeyCode::Key3 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('#')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('£')
+                } else {
+                    DecodedKey::Unicode('3')
+                }
+            }
+            KeyCode::Key4 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('¤')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('$')
+                } else {
+                    DecodedKey::Unicode('4')
+                }
+            }
+            KeyCode::Key5 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('%')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('€')
+                } else {
+                    DecodedKey::Unicode('5')
+                }
+            }
+            KeyCode::Key6 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('&')
+                } else {
+                    DecodedKey::Unicode('6')
+                }
+            }
+            KeyCode::Key7 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('/')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('{')
+                } else {
+                    DecodedKey::Unicode('7')
+                }
+            }
+            KeyCode::Key8 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('(')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('[')
+                } else {
+                    DecodedKey::Unicode('8')
+                }
+            }
+            KeyCode::Key9 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode(')')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode(']')
+                } else {
+                    DecodedKey::Unicode('9')
+                }
+            }
+            KeyCode::Key0 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('=')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('}')
+                } else {
+                    DecodedKey::Unicode('0')
+                }
+            }
+            KeyCode::OemMinus => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('?')
+                } else {
+                    DecodedKey::Unicode('+')
+                }
+            }
+            KeyCode::OemPlus => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('`')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('´')
+                } else {
+                    DecodedKey::Unicode('\\')
+                }
+            }
+            KeyCode::Backspace => DecodedKey::Unicode(0x08.into()),
+            KeyCode::Tab => DecodedKey::Unicode(0x09.into()),
+            KeyCode::Q => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0011}')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('Q')
+                } else {
+                    DecodedKey::Unicode('q')
+                }
+            }
+            KeyCode::E => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{0005}')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('€')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('E')
+                } else {
+                    DecodedKey::Unicode('e')
+                }
+            }
+            KeyCode::Oem4 => {
+                if modifiers.is_caps() {
+                    DecodedKey::Unicode('Å')
+                } else {
+                    DecodedKey::Unicode('å')
+                }
+            }
+            KeyCode::Oem6 => {
+                if modifiers.is_altgr() {
+                    DecodedKey::Unicode('~')
+                } else if modifiers.is_shifted() {
+                    DecodedKey::Unicode('^')
+                } else {
+                    DecodedKey::Unicode('¨')
+                }
+            }
+            KeyCode::Return => DecodedKey::Unicode(10.into()),
+            KeyCode::Oem7 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('*')
+                } else {
+                    DecodedKey::Unicode('\'')
+                }
+            }
+            KeyCode::Oem1 => {
+                if modifiers.is_caps() {
+                    DecodedKey::Unicode('Ø')
+                } else {
+                    DecodedKey::Unicode('ø')
+                }
+            }
+            KeyCode::Oem3 => {
+                if modifiers.is_caps() {
+                    DecodedKey::Unicode('Æ')
+                } else {
+                    DecodedKey::Unicode('æ')
+                }
+            }
+            KeyCode::OemComma => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode(';')
+                } else {
+                    DecodedKey::Unicode(',')
+                }
+            }
+            KeyCode::OemPeriod => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode(':')
+                } else {
+                    DecodedKey::Unicode('.')
+                }
+            }
+            KeyCode::Oem2 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('_')
+                } else {
+                    DecodedKey::Unicode('-')
+                }
+            }
+            KeyCode::Oem5 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('>')
+                } else {
+                    DecodedKey::Unicode('<')
+                }
+            }
+            e => {
+                let us = super::Us104Key;
+                us.map_keycode(e, modifiers, handle_ctrl)
+            }
+        }
+    }
+}

--- a/src/layouts/no105.rs
+++ b/src/layouts/no105.rs
@@ -128,15 +128,6 @@ impl KeyboardLayout for No105Key {
             }
             KeyCode::Backspace => DecodedKey::Unicode(0x08.into()),
             KeyCode::Tab => DecodedKey::Unicode(0x09.into()),
-            KeyCode::Q => {
-                if map_to_unicode && modifiers.is_ctrl() {
-                    DecodedKey::Unicode('\u{0011}')
-                } else if modifiers.is_caps() {
-                    DecodedKey::Unicode('Q')
-                } else {
-                    DecodedKey::Unicode('q')
-                }
-            }
             KeyCode::E => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{0005}')

--- a/src/layouts/uk105.rs
+++ b/src/layouts/uk105.rs
@@ -16,7 +16,7 @@ impl KeyboardLayout for Uk105Key {
     ) -> DecodedKey {
         match keycode {
             KeyCode::Oem8 => {
-                if modifiers.alt_gr {
+                if modifiers.is_altgr() {
                     DecodedKey::Unicode('|')
                 } else if modifiers.is_shifted() {
                     DecodedKey::Unicode('¬')
@@ -46,7 +46,7 @@ impl KeyboardLayout for Uk105Key {
                 }
             }
             KeyCode::Key4 => {
-                if modifiers.alt_gr {
+                if modifiers.is_altgr() {
                     DecodedKey::Unicode('€')
                 } else if modifiers.is_shifted() {
                     DecodedKey::Unicode('$')

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,8 +434,10 @@ pub struct Modifiers {
     pub numlock: bool,
     /// The caps lock toggle is on
     pub capslock: bool,
-    /// The RAlt key is down
-    pub alt_gr: bool,
+    /// The left alt key is down
+    pub lalt: bool,
+    /// The right alt key is down
+    pub ralt: bool,
     /// Special 'hidden' control key is down (used when you press Pause)
     pub rctrl2: bool,
 }
@@ -654,7 +656,8 @@ where
                 rctrl: false,
                 numlock: true,
                 capslock: false,
-                alt_gr: false,
+                lalt: false,
+                ralt: false,
                 rctrl2: false,
             },
             layout,
@@ -757,17 +760,31 @@ where
                 None
             }
             KeyEvent {
+                code: KeyCode::LAlt,
+                state: KeyState::Down,
+            } => {
+                self.modifiers.lalt = true;
+                Some(DecodedKey::RawKey(KeyCode::LAlt))
+            }
+            KeyEvent {
+                code: KeyCode::LAlt,
+                state: KeyState::Up,
+            } => {
+                self.modifiers.lalt = false;
+                None
+            }
+            KeyEvent {
                 code: KeyCode::RAltGr,
                 state: KeyState::Down,
             } => {
-                self.modifiers.alt_gr = true;
+                self.modifiers.ralt = true;
                 Some(DecodedKey::RawKey(KeyCode::RAltGr))
             }
             KeyEvent {
                 code: KeyCode::RAltGr,
                 state: KeyState::Up,
             } => {
-                self.modifiers.alt_gr = false;
+                self.modifiers.ralt = false;
                 None
             }
             KeyEvent {
@@ -825,8 +842,16 @@ impl Modifiers {
         self.lctrl | self.rctrl
     }
 
+    pub const fn is_alt(&self) -> bool {
+        self.lalt | self.ralt
+    }
+
+    pub const fn is_altgr(&self) -> bool {
+        self.ralt | (self.lalt & self.is_ctrl())
+    }
+
     pub const fn is_caps(&self) -> bool {
-        (self.lshift | self.rshift) ^ self.capslock
+        self.is_shifted() ^ self.capslock
     }
 }
 


### PR DESCRIPTION
At least in the Norwegian keyboard layout, Ctrl+Alt is equal to AltGr.

- Added helper functions and updated existing code and layouts to recognize Ctrl+Alt as AltGr.
- Added the Norwegian keyboard layout

Also, the right alt key is only AltGr on *some* keyboard layouts, not all layouts have an AltGr key. I haven't changed anything in this regard, but it might be useful to make that distinction in the different keyboard layouts in the future (instead of in `EventDecoder::process_keyevent`).