### PR TITLE
Fix Norwegian layout

### DIFF
--- a/src/layouts/no105.rs
+++ b/src/layouts/no105.rs
@@ -216,6 +216,13 @@ impl KeyboardLayout for No105Key {
                     DecodedKey::Unicode('<')
                 }
             }
+            KeyCode::NumpadPeriod => {
+                if modifiers.numlock {
+                    DecodedKey::Unicode(',')
+                } else {
+                    DecodedKey::Unicode(127.into())
+                }
+            }
             e => {
                 let us = super::Us104Key;
                 us.map_keycode(e, modifiers, handle_ctrl)

--- a/src/layouts/no105.rs
+++ b/src/layouts/no105.rs
@@ -177,6 +177,17 @@ impl KeyboardLayout for No105Key {
                     DecodedKey::Unicode('æ')
                 }
             }
+            KeyCode::M => {
+                if map_to_unicode && modifiers.is_ctrl() {
+                    DecodedKey::Unicode('\u{000D}')
+                } else if modifiers.is_altgr() {
+                    DecodedKey::Unicode('µ')
+                } else if modifiers.is_caps() {
+                    DecodedKey::Unicode('M')
+                } else {
+                    DecodedKey::Unicode('m')
+                }
+            }
             KeyCode::OemComma => {
                 if modifiers.is_shifted() {
                     DecodedKey::Unicode(';')


### PR DESCRIPTION
#34 seems to have missed the [µ sign](https://en.wikipedia.org/wiki/Micro-) and the fact that someone in the Nordics at some point in the past decided that using comma instead of period as the decimal separator was a great idea.