### PR TITLE
Azerty: add Oem10 for '<'/'>' key (US '\'/'|') between left shift and 'W'/'Z'.

### DIFF
--- a/src/layouts/azerty.rs
+++ b/src/layouts/azerty.rs
@@ -22,9 +22,9 @@ impl KeyboardLayout for Azerty {
             KeyCode::Oem8 => DecodedKey::Unicode('²'),
             KeyCode::Oem5 => {
                 if modifiers.is_shifted() {
-                    DecodedKey::Unicode('*')
-                } else {
                     DecodedKey::Unicode('µ')
+                } else {
+                    DecodedKey::Unicode('*')
                 }
             }
             KeyCode::Key1 => {

--- a/src/layouts/azerty.rs
+++ b/src/layouts/azerty.rs
@@ -22,9 +22,9 @@ impl KeyboardLayout for Azerty {
             KeyCode::Oem8 => DecodedKey::Unicode('²'),
             KeyCode::Oem5 => {
                 if modifiers.is_shifted() {
-                    DecodedKey::Unicode('>')
+                    DecodedKey::Unicode('µ')
                 } else {
-                    DecodedKey::Unicode('<')
+                    DecodedKey::Unicode('*')
                 }
             }
             KeyCode::Key1 => {
@@ -349,6 +349,13 @@ impl KeyboardLayout for Azerty {
             }
             // Enter gives LF, not CRLF or CR
             KeyCode::Return => DecodedKey::Unicode(10.into()),
+            KeyCode::Oem10 => {
+                if modifiers.is_shifted() {
+                    DecodedKey::Unicode('>')
+                } else {
+                    DecodedKey::Unicode('<')
+                }
+            }
             KeyCode::Z => {
                 if map_to_unicode && modifiers.is_ctrl() {
                     DecodedKey::Unicode('\u{0017}')

--- a/src/layouts/azerty.rs
+++ b/src/layouts/azerty.rs
@@ -22,9 +22,9 @@ impl KeyboardLayout for Azerty {
             KeyCode::Oem8 => DecodedKey::Unicode('²'),
             KeyCode::Oem5 => {
                 if modifiers.is_shifted() {
-                    DecodedKey::Unicode('µ')
+                    DecodedKey::Unicode('>')
                 } else {
-                    DecodedKey::Unicode('*')
+                    DecodedKey::Unicode('<')
                 }
             }
             KeyCode::Key1 => {
@@ -533,6 +533,10 @@ mod test {
         );
         assert_eq!(
             k.process_keyevent(KeyEvent::new(KeyCode::NumpadMultiply, KeyState::Down)),
+            Some(DecodedKey::Unicode('*'))
+        );
+        assert_eq!(
+            k.process_keyevent(KeyEvent::new(KeyCode::Oem5, KeyState::Down)),
             Some(DecodedKey::Unicode('*'))
         );
         assert_eq!(


### PR DESCRIPTION
To resolve <https://github.com/Neotron-Compute/Neotron-Desktop-BIOS/issues/14>, I added Oem10 for Azerty '<'/'>' key (US '\'/'|') between left shift and 'W'/'Z'.