### PR TITLE
Fix the 'layout' example.

### DIFF
--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -29,7 +29,7 @@ fn main() {
         code: KeyCode::LShift,
         state: KeyState::Down,
     });
-    assert_eq!(None, decoded_key);
+    assert_eq!(Some(DecodedKey::RawKey(KeyCode::LShift)), decoded_key);
 
     // User presses 'A' on their UK keyboard, now gets a Capital A
     let decoded_key = decoder.process_keyevent(KeyEvent {


### PR DESCRIPTION
You now get the LShift keycode when shift is press, rather than nothing.