### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0 (30 April 2026)
+
 * Fix Ctrl combination handling for Colemak and De105Key layouts
 * Fix 102/105-key German layout: Add missing Alt-Gr combinations
 * Added tool to print keyboard layouts as ASCII-art

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pc-keyboard"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>", "Rust Embedded Community Contributors"]
 description = "PS/2 keyboard interface library."
 keywords = ["keyboard", "ps2", "scancode", "layout"]

--- a/examples/print_keyboard.rs
+++ b/examples/print_keyboard.rs
@@ -65,32 +65,66 @@ fn show_kb(layout: &dyn KeyboardLayout) {
     println!("/// ## Unmodified");
     show_kb_modifiers(layout, &modifiers);
 
+    with_capslock(&mut modifiers, |m| {
+        println!("/// ## Caps Lock");
+        show_kb_modifiers(layout, m);
+    });
+
+    with_lshift(&mut modifiers, |m| {
+        println!("/// ## Shifted");
+        show_kb_modifiers(layout, m);
+    });
+
+    with_rctrl(&mut modifiers, |m| {
+        println!("/// ## Control");
+        show_kb_modifiers(layout, m);
+    });
+
+    with_ralt(&mut modifiers, |m| {
+        println!("/// ## AltGr");
+        show_kb_modifiers(layout, m);
+
+        with_lshift(m, |m2| {
+            println!("/// ## Shift AltGr");
+            show_kb_modifiers(layout, m2);
+        });
+    });
+}
+
+fn with_capslock<F>(modifiers: &mut Modifiers, f: F)
+where
+    F: FnOnce(&mut Modifiers),
+{
     modifiers.capslock = true;
-    println!("/// ## Caps Lock");
-    show_kb_modifiers(layout, &modifiers);
+    f(modifiers);
     modifiers.capslock = false;
+}
 
+fn with_lshift<F>(modifiers: &mut Modifiers, f: F)
+where
+    F: FnOnce(&mut Modifiers),
+{
     modifiers.lshift = true;
-    println!("/// ## Shifted");
-    show_kb_modifiers(layout, &modifiers);
+    f(modifiers);
     modifiers.lshift = false;
+}
 
+fn with_rctrl<F>(modifiers: &mut Modifiers, f: F)
+where
+    F: FnOnce(&mut Modifiers),
+{
     modifiers.rctrl = true;
-    println!("/// ## Control");
-    show_kb_modifiers(layout, &modifiers);
+    f(modifiers);
     modifiers.rctrl = false;
+}
 
+fn with_ralt<F>(modifiers: &mut Modifiers, f: F)
+where
+    F: FnOnce(&mut Modifiers),
+{
     modifiers.ralt = true;
-    println!("/// ## AltGr");
-    show_kb_modifiers(layout, &modifiers);
+    f(modifiers);
     modifiers.ralt = false;
-
-    modifiers.ralt = true;
-    modifiers.lshift = true;
-    println!("/// ## Shift AltGr");
-    show_kb_modifiers(layout, &modifiers);
-    modifiers.ralt = false;
-    modifiers.lshift = false;
 }
 
 fn show_kb_modifiers(layout: &dyn KeyboardLayout, modifiers: &Modifiers) {


### PR DESCRIPTION
* Update the print_keyboard example code to avoid warnings about unused variables
* Bump to v0.9.0